### PR TITLE
#1 - use image_url when present

### DIFF
--- a/server/modules/cleaner.js
+++ b/server/modules/cleaner.js
@@ -49,7 +49,7 @@ module.exports = {
         card.subroutines = subs;
       }
       
-      card.imagesrc = img.replace('{code}', card.code);
+      card.imagesrc = card.image_url || img.replace('{code}', card.code);
 
       return card.imagesrc && card.pack_code != 'draft';
     });


### PR DESCRIPTION
Fix for the broken images, turns out it's only that some use cardgamedb URLs (not sure why) - just need to use them when present.