### PR TITLE
#4 store images locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/*
 public/js/app.js
 public/js/data.js
 public/css/app.css
+public/img/cards/*
 import/*.json
 todos.txt
 assets/*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,3 +9,5 @@ Vagrant.configure("2") do |config|
     
     config.vm.provision :shell, path: "bootstrap.sh"
 end
+
+# note that for some reason vagrant up won't work for dev, it's need re-provisioning: vagrant up --provision

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-uglify": "^1.5.1",
     "mongojs": "^2.4.0",
     "request": "^2.69.0",
+    "rimraf": "^2.6.2",
     "uglify-js": "^2.6.2"
   },
   "devDependencies": {

--- a/server/flush.js
+++ b/server/flush.js
@@ -1,5 +1,17 @@
 var db = require('./modules/db');
+var rimraf = require('rimraf');
+var fs = require('fs');
+
+var cardDir = __dirname + '/../public/img/cards';
+var images = process.argv.slice(2);
 
 db.collection('modified').drop((err, res) => {
   db.close();
+  if (images != 'skipimages') {
+    rimraf(cardDir, function() {
+      if (!fs.existsSync(cardDir)){
+        fs.mkdirSync(cardDir);
+      }
+    });
+  }
 });


### PR DESCRIPTION
When importing, this fix will pull the images down too and store them locally meaning that we don't have to rely on other providers for the images. However, this does mean our bandwidth may increase so we'll have to keep an eye on that.